### PR TITLE
Add Codex Remix section to 2025 page

### DIFF
--- a/public/era/2025/main.js
+++ b/public/era/2025/main.js
@@ -78,3 +78,14 @@ if (carousel) {
     }, 4000);
   });
 }
+
+const codexButton = document.querySelector('.codex-trigger');
+const codexStatus = document.getElementById('codex-status');
+if (codexButton && codexStatus) {
+  codexButton.addEventListener('click', () => {
+    const now = new Date();
+    codexStatus.textContent = `Status: checkpoint passed at ${now.toLocaleTimeString()}.`;
+    codexButton.textContent = 'Checkpoint Complete';
+    codexButton.disabled = true;
+  });
+}

--- a/public/era/2025/styles.css
+++ b/public/era/2025/styles.css
@@ -212,6 +212,42 @@ body, html {
   padding-bottom: 200px;
 }
 
+.codex-section {
+  max-width: 800px;
+  margin: 2rem auto 4rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(0, 255, 225, 0.4);
+  border-radius: 12px;
+  background: linear-gradient(145deg, rgba(8, 8, 8, 0.95), rgba(22, 22, 22, 0.9));
+  box-shadow: 0 0 24px rgba(0, 255, 225, 0.2);
+}
+
+.codex-section h2 {
+  margin-top: 0;
+}
+
+.codex-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.codex-trigger {
+  background: #0f766e;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.7rem 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.codex-trigger:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(15, 118, 110, 0.4);
+}
+
 .mistake-card {
   background: #111;
   border-left: 4px solid #e1e1e1;

--- a/src/era/2025/index.html
+++ b/src/era/2025/index.html
@@ -282,6 +282,14 @@ Reflection:
         <a href="/profile/Deep_Joshi_CV.pdf" class="cta-button" download>Download CV</a>
       </div>
     </section>
+    <section class="codex-section reveal-section" id="codex-version">
+      <h2>Codex Remix</h2>
+      <p>This version was refreshed by Codex with a small interactive checkpoint for newcomers.</p>
+      <div class="codex-card">
+        <p id="codex-status">Status: waiting for your click.</p>
+        <button class="codex-trigger" type="button">Run Codex Checkpoint</button>
+      </div>
+    </section>
     <footer class="footer">
         <p>&copy; 2025 Deep Joshi. All rights reserved. Not really.</p>
     </footer>


### PR DESCRIPTION
### Motivation
- Provide a visible, Codex-branded variant of the 2025 era page to demonstrate an automated content refresh and a simple interactive checkpoint. 
- Surface a lightweight, discoverable interaction so newcomers can observe a client-side state change without altering core site flows. 
- Keep changes scoped and reversible by adding a new section, styles, and small JS behavior rather than refactoring existing components.

### Description
- Added a new `Codex Remix` section to the 2025 page at `src/era/2025/index.html` containing a status line and a checkpoint button. 
- Implemented styles for the new section and button in `public/era/2025/styles.css` to match the site aesthetic and provide hover feedback. 
- Added client-side interaction in `public/era/2025/main.js` so clicking the checkpoint updates the status with a timestamp and disables the button. 
- Changes were made on a working branch named `codex-changes` to keep the work isolated.

### Testing
- Ran `npm ci` successfully to install dependencies. 
- Built the site with `npm run build` and the build completed without errors. 
- Launched a local dev server with `npm run dev` and confirmed the page served at `/profile/`. 
- Captured a Playwright screenshot of the updated page as visual validation and the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69983cfd9bc88331b7cc6756386fe281)